### PR TITLE
Update middleman-fontcustom.gemspec

### DIFF
--- a/middleman-fontcustom.gemspec
+++ b/middleman-fontcustom.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_runtime_dependency "middleman-core", "~> 3.3.7"
+  s.add_runtime_dependency "middleman-core", "~> 3.3", ">= 3.3.7"
   s.add_runtime_dependency "fontcustom", "~> 1.3.7"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Forward compatibility with Middleman minor version updates

I'm trying to use the `v3-stable` branch of `middleman` to take advantage of some new features slated for version 3.4.0, but the previous `middleman-fontcustom` Gemspec specifies `~> 3.3.7` which doesn't allow for using the latest version of Middleman. Everything seems to be working just fine.