### PR TITLE
New option for fontcustom, versioning changed 

### DIFF
--- a/lib/middleman-fontcustom/extension.rb
+++ b/lib/middleman-fontcustom/extension.rb
@@ -9,6 +9,7 @@ module Middleman
     option :templates, 'scss', 'Output templates'
     option :no_hash, true, 'Create hash for no cache policy'
     option :preprocessor_path, nil, 'Relative path from your compiled CSS to your output directory'
+    option :autowidth, true, 'Trims horizontal white space from each glyph.'
 
     def initialize(app, options_hash={}, &block)
       super
@@ -27,7 +28,8 @@ module Middleman
           },
           :templates => config[:templates].split(/\s/),
           :no_hash => config[:no_hash],
-          :preprocessor_path => config[:preprocessor_path]
+          :preprocessor_path => config[:preprocessor_path],
+          :autowidth => config[:autowidth]
         }).compile
       }
 

--- a/lib/middleman-fontcustom/extension.rb
+++ b/lib/middleman-fontcustom/extension.rb
@@ -9,7 +9,7 @@ module Middleman
     option :templates, 'scss', 'Output templates'
     option :no_hash, true, 'Create hash for no cache policy'
     option :preprocessor_path, nil, 'Relative path from your compiled CSS to your output directory'
-    option :autowidth, true, 'Trims horizontal white space from each glyph.'
+    option :autowidth, false, 'Trims horizontal white space from each glyph.'
 
     def initialize(app, options_hash={}, &block)
       super

--- a/middleman-fontcustom.gemspec
+++ b/middleman-fontcustom.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_runtime_dependency "middleman-core", "~> 3.3", ">= 3.3.7"
-  s.add_runtime_dependency "fontcustom", "~> 1.3.7"
+  s.add_runtime_dependency "middleman-core", ">= 3.3"
+  s.add_runtime_dependency "fontcustom", "~> 1.3"
 
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
I've added an option to set the autowidth property used by fontcustom to automatically trim the icons.

Also; when using middleman 4, this extension gave a dependency error even though it didn't need to (seems to work just fine with the MM beta)
